### PR TITLE
urlparse only works with python2

### DIFF
--- a/git-get
+++ b/git-get
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Like go get but without the need for go.
 
 import sys


### PR DESCRIPTION
Hi, I had python3 as a default python and `git-get` won't work:

```
git-get
Traceback (most recent call last):
  File "/home/lorn/.scripts/tools/git-get", line 7, in <module>
    import urlparse
ModuleNotFoundError: No module named 'urlparse'
```

So, I changed the first line to use the default python2 and everything works

> The urlparse module is renamed to urllib.parse in Python 3.
> The 2to3 tool will automatically adapt imports when converting
> your sources to Python 3.

https://docs.python.org/2/library/urlparse.html