### PR TITLE
Migration to python3

### DIFF
--- a/git-get
+++ b/git-get
@@ -1,11 +1,10 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Like go get but without the need for go.
 
 import sys
 import os
 import subprocess
-import urlparse
-import string
+from urllib.parse import urlparse
 
 
 def eprint(msg):
@@ -52,8 +51,8 @@ if git_url.startswith('git@'):
     url_for_path_parsing = 'https://' + git_url.replace(':', '/')
 
 try:
-    parsed_url = urlparse.urlparse(url_for_path_parsing)
-    pathend = string.strip(os.path.splitext(parsed_url.path)[0], '/')
+    parsed_url = urlparse(url_for_path_parsing)
+    pathend = os.path.splitext(parsed_url.path)[0].strip('/')
     path = os.path.join(base_dir, parsed_url.hostname, pathend)
 except Exception:
     eprint('Could not parse url %s' % git_url)


### PR DESCRIPTION
I wanted to use this tool in Ubuntu 20.04, but python2 is literally not installed, and I don't want to install python2 when python3 is the packaged standard now. So have updated the python script to run with python3. 